### PR TITLE
Big update

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -4,14 +4,18 @@
       "name":"inline_toolbar",
       "post": ["ep_etherpad-lite/static"],
       "client_hooks": {
+        "postAceInit": "ep_inline_toolbar/static/js/index",
         "aceEditorCSS": "ep_inline_toolbar/static/js/index",
         "aceSelectionChanged": "ep_inline_toolbar/static/js/index"
       },
       "hooks": {
+        "loadSettings": "ep_inline_toolbar/index",
+        "eejsBlock_body": "ep_inline_toolbar/index",
         "eejsBlock_scripts": "ep_inline_toolbar/index",
         "eejsBlock_mySettings": "ep_inline_toolbar/index",
         "eejsBlock_styles": "ep_inline_toolbar/index",
-        "clientVars": "ep_inline_toolbar/index"
+        "clientVars": "ep_inline_toolbar/index",
+        "padInitToolbar": "ep_inline_toolbar/index"
       }
     }
   ]

--- a/ep.json
+++ b/ep.json
@@ -8,16 +8,17 @@
         "postAceInit": "ep_inline_toolbar/static/js/index",
         "aceEditorCSS": "ep_inline_toolbar/static/js/index",
         "aceSelectionChanged": "ep_inline_toolbar/static/js/index",
-        "aceInitialized": "ep_inline_toolbar/static/js/index"
+        "aceInitialized": "ep_inline_toolbar/static/js/index",
+        "postToolbarInit": "ep_inline_toolbar/static/js/index"
       },
       "hooks": {
         "loadSettings": "ep_inline_toolbar/index",
-        "clientVars": "ep_inline_toolbar/index",
         "eejsBlock_body": "ep_inline_toolbar/index",
         "eejsBlock_scripts": "ep_inline_toolbar/index",
         "eejsBlock_mySettings": "ep_inline_toolbar/index",
         "eejsBlock_styles": "ep_inline_toolbar/index",
-        "padInitToolbar": "ep_inline_toolbar/index"
+        "padInitToolbar": "ep_inline_toolbar/index",
+        "clientVars": "ep_inline_toolbar/index"
       }
     }
   ]

--- a/ep.json
+++ b/ep.json
@@ -3,6 +3,7 @@
     {
       "name":"inline_toolbar",
       "post": ["ep_etherpad-lite/static"],
+      "pre": ["ep_*"],
       "client_hooks": {
         "postAceInit": "ep_inline_toolbar/static/js/index",
         "aceEditorCSS": "ep_inline_toolbar/static/js/index",

--- a/ep.json
+++ b/ep.json
@@ -7,10 +7,12 @@
       "client_hooks": {
         "postAceInit": "ep_inline_toolbar/static/js/index",
         "aceEditorCSS": "ep_inline_toolbar/static/js/index",
-        "aceSelectionChanged": "ep_inline_toolbar/static/js/index"
+        "aceSelectionChanged": "ep_inline_toolbar/static/js/index",
+        "aceInitialized": "ep_inline_toolbar/static/js/index"
       },
       "hooks": {
         "loadSettings": "ep_inline_toolbar/index",
+        "clientVars": "ep_inline_toolbar/index",
         "eejsBlock_body": "ep_inline_toolbar/index",
         "eejsBlock_scripts": "ep_inline_toolbar/index",
         "eejsBlock_mySettings": "ep_inline_toolbar/index",

--- a/ep.json
+++ b/ep.json
@@ -15,7 +15,6 @@
         "eejsBlock_scripts": "ep_inline_toolbar/index",
         "eejsBlock_mySettings": "ep_inline_toolbar/index",
         "eejsBlock_styles": "ep_inline_toolbar/index",
-        "clientVars": "ep_inline_toolbar/index",
         "padInitToolbar": "ep_inline_toolbar/index"
       }
     }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,12 @@ exports.loadSettings = function (hook_name, context) {
     inlineMenuItems = context.settings.toolbar.inline;
 };
 
+exports.clientVars = function(hook, context, callback)
+{
+  // tell the client which year we are in
+  return callback({ "ep_inline_toolbar": settings.ep_inline_toolbar });
+};
+
 exports.padInitToolbar = function (hook_name, context) {
     var availableButtons = context.toolbar.availableButtons;
 
@@ -58,7 +64,6 @@ exports.padInitToolbar = function (hook_name, context) {
 
             inlineButtons.push(buttons);
         }
-        console.log(inlineButtons);
     });
 };
 

--- a/index.js
+++ b/index.js
@@ -13,64 +13,74 @@ exports.loadSettings = function (hook_name, context) {
 exports.clientVars = function(hook, context, callback)
 {
   // tell the client which year we are in
-  return callback({ "ep_inline_toolbar": settings.ep_inline_toolbar });
+  createInlineToolbar();
+  return callback({ "ep_inline_toolbar": settings.ep_inline_toolbar, "inlineButtons": inlineButtons });
 };
 
-exports.padInitToolbar = function (hook_name, context) {
-    var availableButtons = context.toolbar.availableButtons;
+var createInlineToolbar = function () {
+  var toolbar = this.toolbar;
+  if (toolbar) {
+      
+    var availableButtons = toolbar.availableButtons;
 
     inlineButtons = [];
     inlineMenuItems.forEach(function (inlineBlock) {
-        if (_.isArray(inlineBlock)) {
-            var buttons = [];
-            inlineBlock.forEach(function (buttonName) {
-              var buttonType = null;
-              var buttonTitle = null;
-              var localizationId = null;
-                if (_.isObject(buttonName)) {
-                  var objKey = Object.keys(buttonName)[0];
-                  var keySettings = buttonName[objKey];
-                  buttonType = keySettings.buttonType;
-                  buttonTitle = keySettings.title;
-                  localizationId = keySettings.localizationId;
-                  buttonName = objKey;
-                }
+      if (_.isArray(inlineBlock)) {
+          var buttons = [];
+          inlineBlock.forEach(function (buttonName) {
+            var buttonType = null;
+            var buttonTitle = null;
+            var localizationId = null;
+              if (_.isObject(buttonName)) {
+                var objKey = Object.keys(buttonName)[0];
+                var keySettings = buttonName[objKey];
+                buttonType = keySettings.buttonType;
+                buttonTitle = keySettings.title;
+                localizationId = keySettings.localizationId;
+                buttonName = objKey;
+              }
 
-                if (availableButtons[buttonName]) {
-                    var buttonItem = availableButtons[buttonName];
-                    if (availableButtons[buttonName].attributes) {
-                      buttonItem = availableButtons[buttonName].attributes;
-                    }
+              if (availableButtons[buttonName]) {
+                  var buttonItem = availableButtons[buttonName];
+                  if (availableButtons[buttonName].attributes) {
+                    buttonItem = availableButtons[buttonName].attributes;
+                  }
 
-                    if (localizationId) {
-                      buttonItem.localizationId = localizationId;
-                      buttonTitle = localizationId;
-                    }
-                    buttonItem = context.toolbar.button(buttonItem);
-                    
-                    var buttonHtml = buttonItem.render();
+                  if (localizationId) {
+                    buttonItem.localizationId = localizationId;
+                    buttonTitle = localizationId;
+                  }
+                  buttonItem = toolbar.button(buttonItem);
+                  
+                  var buttonHtml = buttonItem.render();
 
-                    if (buttonType === 'link') {
-                      buttonHtml = buttonHtml.replace('<button', '<span').replace('</button>', '</span>').replace('data-type="button"', 'data-type="link"');
-                    }
+                  if (buttonType === 'link') {
+                    buttonHtml = buttonHtml.replace('<button', '<span').replace('</button>', '</span>').replace('data-type="button"', 'data-type="link"');
+                  }
 
-                    if (buttonTitle) {
-                      buttonHtml = buttonHtml.replace('</span>', buttonTitle +'</span>');
-                    }
+                  if (buttonTitle) {
+                    buttonHtml = buttonHtml.replace('</span>', buttonTitle +'</span>');
+                  }
 
-                    buttons.push(buttonHtml);
-                }   
-              });
+                  buttons.push(buttonHtml);
+              }   
+            });
 
-            inlineButtons.push(buttons);
-        }
+          inlineButtons.push(buttons);
+      }
     });
+  }
 };
 
+
+exports.padInitToolbar = function (hook_name, context) {
+  createInlineToolbar = _(createInlineToolbar).bind(context);
+};
+
+
 exports.eejsBlock_body = function (hook_name, args, cb) {
-  args.content = args.content + eejs.require("ep_inline_toolbar/templates/menuButtons.ejs", {
-    buttons: inlineButtons
-  });
+  args.content = args.content + eejs.require("ep_inline_toolbar/templates/menuButtons.ejs");
+
   return cb();
 };
 

--- a/index.js
+++ b/index.js
@@ -12,15 +12,47 @@ exports.loadSettings = function (hook_name, context) {
 
 exports.padInitToolbar = function (hook_name, context) {
     var availableButtons = context.toolbar.availableButtons;
+
     inlineButtons = [];
     inlineMenuItems.forEach(function (inlineBlock) {
         if (_.isArray(inlineBlock)) {
             var buttons = [];
             inlineBlock.forEach(function (buttonName) {
-                if (availableButtons[buttonName]) {
-                    var buttonItem = context.toolbar.button(availableButtons[buttonName]);
+              var buttonType = null;
+              var buttonTitle = null;
+              var localizationId = null;
+                if (_.isObject(buttonName)) {
+                  var objKey = Object.keys(buttonName)[0];
+                  var keySettings = buttonName[objKey];
+                  buttonType = keySettings.buttonType;
+                  buttonTitle = keySettings.title;
+                  localizationId = keySettings.localizationId;
+                  buttonName = objKey;
+                }
 
-                    buttons.push(buttonItem.render());
+                if (availableButtons[buttonName]) {
+                    var buttonItem = availableButtons[buttonName];
+                    if (availableButtons[buttonName].attributes) {
+                      buttonItem = availableButtons[buttonName].attributes;
+                    }
+
+                    if (localizationId) {
+                      buttonItem.localizationId = localizationId;
+                      buttonTitle = localizationId;
+                    }
+                    buttonItem = context.toolbar.button(buttonItem);
+                    
+                    var buttonHtml = buttonItem.render();
+
+                    if (buttonType === 'link') {
+                      buttonHtml = buttonHtml.replace('<button', '<span').replace('</button>', '</span>').replace('data-type="button"', 'data-type="link"');
+                    }
+
+                    if (buttonTitle) {
+                      buttonHtml = buttonHtml.replace('</span>', buttonTitle +'</span>');
+                    }
+
+                    buttons.push(buttonHtml);
                 }   
               });
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,39 @@
 var eejs = require('ep_etherpad-lite/node/eejs/');
 var settings = require('ep_etherpad-lite/node/utils/Settings');
 
-exports.eejsBlock_dd_insert = function (hook_name, args, cb) {
-  args.content = args.content + eejs.require("ep_inline_toolbar/templates/menuButtons.ejs");
+var _ = require('underscore');
+
+var inlineMenuItems;
+var inlineButtons = [];
+
+exports.loadSettings = function (hook_name, context) {
+    inlineMenuItems = context.settings.toolbar.inline;
+};
+
+exports.padInitToolbar = function (hook_name, context) {
+    var availableButtons = context.toolbar.availableButtons;
+    inlineButtons = [];
+    inlineMenuItems.forEach(function (inlineBlock) {
+        if (_.isArray(inlineBlock)) {
+            var buttons = [];
+            inlineBlock.forEach(function (buttonName) {
+                if (availableButtons[buttonName]) {
+                    var buttonItem = context.toolbar.button(availableButtons[buttonName]);
+
+                    buttons.push(buttonItem.render());
+                }   
+              });
+
+            inlineButtons.push(buttons);
+        }
+        console.log(inlineButtons);
+    });
+};
+
+exports.eejsBlock_body = function (hook_name, args, cb) {
+  args.content = args.content + eejs.require("ep_inline_toolbar/templates/menuButtons.ejs", {
+    buttons: inlineButtons
+  });
   return cb();
 };
 

--- a/index.js
+++ b/index.js
@@ -84,11 +84,3 @@ exports.eejsBlock_styles = function (hook_name, args, cb) {
   args.content = args.content + eejs.require("ep_inline_toolbar/templates/styles.html", {}, module);
   return cb();
 };
-
-
-// not used
-exports.clientVars = function (hook, context, cb) {
-  var displayCommentAsIcon = settings.ep_inline_toolbar ? settings.ep_inline_toolbar.displayCommentAsIcon : false;
-  return cb({ "displayCommentAsIcon": displayCommentAsIcon });
-};
-

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -136,6 +136,8 @@ function getXYOffsetOfRep(selStart, selEnd){
       left = left - padOuter.find("#inline_toolbar").width();
       top  = top +($(div).height()/2);
     } 
+    console.log('SELECTION', selStart, selEnd, top);
+    console.log(div);
     // Remove the element
     $(div).remove();
     //$('iframe[name="ace_outer"]').contents().find('#outerdocbody').contents().remove("#hiddenWorker");

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -251,7 +251,7 @@ exports.postAceInit = function (hook_name, context) {
       
       $(spanItem).html(html10n.get(translationId));
     }
-    $(this).parent().on('click', function () {
+    $(this).on('click', function () {
       iT.hide();
       padEditBar.triggerCommand(command, $(this));
     });

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -2,6 +2,8 @@ var _, $, jQuery;
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
+var padEditBar = require('ep_etherpad-lite/static/js/pad_editbar').padeditbar;
+
 var globalKey = 0;
 
 iT = {
@@ -154,16 +156,6 @@ function getXYOffsetOfRep(selStart, selEnd){
 function drawAt(XY){
   var padOuter = $('iframe[name="ace_outer"]').contents().find("body");
   var toolbar = padOuter.find("#inline_toolbar");
-  if(toolbar.length === 0){
-    padOuter.append("<div id='inline_toolbar' class='toolbar'></div>");
-    var toolbar = padOuter.find("#inline_toolbar");
-    $('.menu_left').clone(true, true).appendTo(toolbar);
-    $(toolbar).find(".menu_left").css("right", "0px");
-    $(toolbar).find(".menu_left").css("margin-left", "0px");
-    $(toolbar).css("background", "none");
-    $(toolbar).css("border-bottom", "none");
-  }
-  var toolbar = padOuter.find("#inline_toolbar");
 
   toolbar.css({
     "position": "absolute"
@@ -241,4 +233,23 @@ function wrap(target, key) { // key can probably be removed here..
     }
   });
   return newtarget.html();
+}
+
+exports.postAceInit = function (hook_name, context) {
+  var ace = context.ace;
+  var pad = context.pad;
+
+  var padOuter = $('iframe[name="ace_outer"]').contents().find("body");
+  
+  $("#inlineToolbar [data-key]").each(function () {
+    $(this).unbind("click");
+    var command = $(this).data('key');
+    $(this).on('click', function () {
+      padEditBar.triggerCommand(command, $(this));
+    });
+  });
+
+  $("#inline_toolbar").detach().appendTo(padOuter[0]);
+  
+  
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -3,6 +3,7 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
 var padEditBar = require('ep_etherpad-lite/static/js/pad_editbar').padeditbar;
+var Security = require('ep_etherpad-lite/static/js/security');
 
 var globalKey = 0;
 
@@ -73,7 +74,9 @@ function getXYOffsetOfRep(selStart, selEnd){
     var top = divEl.offset().top + topCorrection; // A standard generic offset
     // Get the HTML
     var html = $(div).html();
-    var text = $(div).text().split('');
+    var text = $(div).text();
+    text = Security.escapeHTML(text).split('');
+    
     var workerIndex;
     if (viewPosition === 'right') {
       if (selEnd[0] > selStart[0] && selEnd[1] === 0) {
@@ -89,9 +92,11 @@ function getXYOffsetOfRep(selStart, selEnd){
     text.splice(workerIndex, 0, '<span id="selectWorker">');
     var heading = isHeading();
     text = text.join('');
+    
     if (heading) {
       text = '<'+heading+'>' + text + '</'+heading+'>';
     }
+
     $(div).html(text);
     var worker = $(div).find('#selectWorker');
     var workerPosition = worker.position();

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -154,9 +154,11 @@ function getXYOffsetOfRep(selStart, selEnd){
 
 // Draws the toolbar onto the screen
 function drawAt(XY){
+  
   var padOuter = $('iframe[name="ace_outer"]').contents().find("body");
   var toolbar = padOuter.find("#inline_toolbar");
 
+  toolbar.show();
   toolbar.css({
     "position": "absolute"
   });
@@ -236,12 +238,13 @@ function wrap(target, key) { // key can probably be removed here..
 }
 
 exports.postAceInit = function (hook_name, context) {
+  $("#inline_toolbar").hide();
   var ace = context.ace;
   var pad = context.pad;
 
   var padOuter = $('iframe[name="ace_outer"]').contents().find("body");
   
-  $("#inlineToolbar [data-key]").each(function () {
+  $("#inline_toolbar [data-key]").each(function () {
     $(this).unbind("click");
     var command = $(this).data('key');
     $(this).on('click', function () {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -77,8 +77,8 @@ function getXYOffsetOfRep(selStart, selEnd){
     var workerIndex;
     if (viewPosition === 'right') {
       if (selEnd[0] > selStart[0] && selEnd[1] === 0) {
-        var prevLine =  getLineAtIndex(selEnd[0] -1);
-        workerIndex = $(prevLine.lineNode).text().length - 1;
+        line =  getLineAtIndex(selEnd[0] -1);
+        workerIndex = $(line.lineNode).text().length - 1;
       } else {
         workerIndex = selEnd[1];
       }
@@ -87,7 +87,12 @@ function getXYOffsetOfRep(selStart, selEnd){
     }
     text.splice(workerIndex, 0, '</span>');
     text.splice(workerIndex, 0, '<span id="selectWorker">');
-    $(div).html(text.join(''));
+    var heading = isHeading();
+    text = text.join('');
+    if (heading) {
+      text = '<'+heading+'>' + text + '</'+heading+'>';
+    }
+    $(div).html(text);
     var worker = $(div).find('#selectWorker');
     var workerPosition = worker.position();
    
@@ -135,12 +140,9 @@ function getXYOffsetOfRep(selStart, selEnd){
     } else if (viewPosition === 'left') {
       left = left - padOuter.find("#inline_toolbar").width();
       top  = top +($(div).height()/2);
-    } 
-    console.log('SELECTION', selStart, selEnd, top);
-    console.log(div);
+    }
     // Remove the element
     $(div).remove();
-    //$('iframe[name="ace_outer"]').contents().find('#outerdocbody').contents().remove("#hiddenWorker");
     return [left, top];
   }
 }
@@ -249,7 +251,7 @@ exports.postAceInit = function (hook_name, context) {
       
       $(spanItem).html(html10n.get(translationId));
     }
-    $(this).on('click', function () {
+    $(this).parent().on('click', function () {
       iT.hide();
       padEditBar.triggerCommand(command, $(this));
     });
@@ -287,6 +289,24 @@ var getLineAtIndex = function (index) {
   return this.rep.lines.atIndex(index);
 }
 
+var isHeading = function (index) {
+  var index;
+  if (clientVars.ep_inline_toolbar.position === 'top') {
+    index = this.rep.selStart[0];
+  } else {
+    index =  getLastLine(this.rep);
+  }
+  var attribs = this.documentAttributeManager.getAttributesOnLine(index);
+  for (var i=0; i<attribs.length; i++) {
+    if (attribs[i][0] === 'heading') {
+      var value = attribs[i][1];
+      i = attribs.length;
+      return value;
+    }
+  }
+  return false;
+}
+
 var getSelectedLineElement = function () {
   var index;
   if (clientVars.ep_inline_toolbar.position === 'top') {
@@ -302,4 +322,5 @@ var getSelectedLineElement = function () {
 exports.aceInitialized = function(hook, context){
   getSelectedLineElement = _(getSelectedLineElement).bind(context);
   getLineAtIndex = _(getLineAtIndex).bind(context);
+  isHeading = _(isHeading).bind(context);
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -324,3 +324,11 @@ exports.aceInitialized = function(hook, context){
   getLineAtIndex = _(getLineAtIndex).bind(context);
   isHeading = _(isHeading).bind(context);
 }
+
+exports.postToolbarInit = function (hook, context) {
+  if (clientVars.inlineButtons && clientVars.inlineButtons.length) {
+    $.each(clientVars.inlineButtons, function (key, item) {
+      $('#inline_toolbar_menu_items').append(item);
+    });
+  }
+}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -247,6 +247,14 @@ exports.postAceInit = function (hook_name, context) {
   $("#inline_toolbar [data-key]").each(function () {
     $(this).unbind("click");
     var command = $(this).data('key');
+    
+    if ($(this).data('type') === 'link') {
+      $(this).addClass('link');
+      var spanItem = $(this).find('span.buttonicon')[0];
+      var translationId = $(spanItem).data('l10n-id');
+      
+      $(spanItem).html(html10n.get(translationId));
+    }
     $(this).on('click', function () {
       padEditBar.triggerCommand(command, $(this));
     });

--- a/templates/menuButtons.ejs
+++ b/templates/menuButtons.ejs
@@ -1,11 +1,6 @@
 <div id="inline_toolbar" class="toolbar enabledtoolbar" style="display: none">
         <div class="menu_inline" role="toolbar">
-                <ul>
-                        <% for (var i = 0; i < buttons.length; i++) { %>
-                                <% for (var j = 0; j < buttons[i].length; j++) { %>
-                                        <%- buttons[i][j] %>
-                                <% } %>
-                        <% } %>
+                <ul id="inline_toolbar_menu_items">
                 </ul>
         </div>
 </div>

--- a/templates/menuButtons.ejs
+++ b/templates/menuButtons.ejs
@@ -1,3 +1,11 @@
-<li class="addComment">
-    <a title="Add new comment on selection" data-l10n-id="ep_comments_page.add_comment.title"><span data-l10n-id="ep_comments_page.comment">Comment</span></a>
-</li>
+<div id="inline_toolbar" class="toolbar enabledtoolbar" style="display: none">
+        <div class="menu_inline" role="toolbar">
+                <ul>
+                        <% for (var i = 0; i < buttons.length; i++) { %>
+                                <% for (var j = 0; j < buttons[i].length; j++) { %>
+                                        <%- buttons[i][j] %>
+                                <% } %>
+                        <% } %>
+                </ul>
+        </div>
+</div>


### PR DESCRIPTION
Fixed toolbar positioning. Can now change position from settings.json eg. `"ep_inline_toolbar": { "position": "top"}.` Also reads items from settings.json under `"toolbar"`. Buttons can be added by default design like in other menu blocks or as text items eg: `"inline": [
	      [
          {"addComment": {
              "buttonType": "link",
              "title": "Add new comment",
              "localizationId": "ep_comments_page.add_comment.title"
            }
          }
        ]
    ]`
